### PR TITLE
Do not capture child future in TaskGroup::spawn's returned future

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,12 +32,11 @@ impl<E: Send + 'static> TaskGroup<E> {
         &self,
         name: impl AsRef<str>,
         f: impl Future<Output = Result<(), E>> + Send + 'static,
-    ) -> impl Future<Output = Result<(), SpawnError>> {
+    ) -> impl Future<Output = Result<(), SpawnError>> + '_ {
         let name = name.as_ref().to_string();
         let join = tokio::task::spawn(f);
-        let new_task = self.new_task.clone();
         async move {
-            match new_task.send(ChildHandle { name, join }).await {
+            match self.new_task.send(ChildHandle { name, join }).await {
                 Ok(()) => Ok(()),
                 // If there is no receiver alive to manage the new task, drop the child in error to
                 // cancel it:
@@ -51,12 +50,11 @@ impl<E: Send + 'static> TaskGroup<E> {
         name: impl AsRef<str>,
         runtime: tokio::runtime::Handle,
         f: impl Future<Output = Result<(), E>> + Send + 'static,
-    ) -> impl Future<Output = Result<(), SpawnError>> {
+    ) -> impl Future<Output = Result<(), SpawnError>> + '_ {
         let name = name.as_ref().to_string();
         let join = runtime.spawn(f);
-        let new_task = self.new_task.clone();
         async move {
-            match new_task.send(ChildHandle { name, join }).await {
+            match self.new_task.send(ChildHandle { name, join }).await {
                 Ok(()) => Ok(()),
                 // If there is no receiver alive to manage the new task, drop the child in error to
                 // cancel it:
@@ -69,12 +67,11 @@ impl<E: Send + 'static> TaskGroup<E> {
         &self,
         name: impl AsRef<str>,
         f: impl Future<Output = Result<(), E>> + 'static,
-    ) -> impl Future<Output = Result<(), SpawnError>> {
+    ) -> impl Future<Output = Result<(), SpawnError>> + '_ {
         let name = name.as_ref().to_string();
         let join = tokio::task::spawn_local(f);
-        let new_task = self.new_task.clone();
         async move {
-            match new_task.send(ChildHandle { name, join }).await {
+            match self.new_task.send(ChildHandle { name, join }).await {
                 Ok(()) => Ok(()),
                 // If there is no receiver alive to manage the new task, drop the child in error to
                 // cancel it:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,8 +557,12 @@ mod test {
 
         async fn big_future() -> Result<(), ()> {
             let big_object = [0_u8; 4096];
-            // Hold _big_object across an await point
+            // Hold big_object across an await point
             async { () }.await;
+            println!(
+                "printing big_object to keep value from being optimized out: {:?}",
+                big_object
+            );
             drop(big_object);
             Ok(())
         }


### PR DESCRIPTION
Closes #3 

This PR follows @timotree3's suggestion in #3 to change the implementation of TaskGroup::{spawn, spawn_on, spawn_local} so that the Future returned by those methods is smaller in size, by not capturing the child Future.

I added a regression check based on the bug report, replacing the hard-coded sizes with a greater-than assertion to hopefully be less fragile if something in Rust changes. Still, I'm not sure how fragile this might be, since I don't understand enough about the assumptions rustc and LLVM can make about these values, and how those might change.